### PR TITLE
Enlarge chord identifier dialogue

### DIFF
--- a/chordIdentifierPopJazz.qml
+++ b/chordIdentifierPopJazz.qml
@@ -77,8 +77,8 @@ MuseScore {
 
     requiresScore: true
 
-    width: 464
-    height: 298
+    width: 800
+    height: 400
 
     // Settings
     Settings {


### PR DESCRIPTION
The buttons were cut off for me, so I increase the dialogue size.

I couldn't figure out how to make the dialog resizable, although that would be preferable.

Thanks for the 4.4 patch!